### PR TITLE
Fix small typo in astro.ts

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -553,7 +553,7 @@ export interface AstroUserConfig {
 	 *
 	 * Specifies the output target for builds.
 	 *
-	 * - `'static'` - Building a static site to be deploy to any static host.
+	 * - `'static'` - Building a static site to be deployed to any static host.
 	 * - `'server'` - Building an app to be deployed to a host supporting SSR (server-side rendering).
 	 * - `'hybrid'` - Building a static site with a few server-side rendered pages.
 	 *


### PR DESCRIPTION
This fixes a small typo in the output section of the types documentation.  Replaces PR #6792 in docs repository

## Changes

- A minor typo in the output section of configuration documentation is fixed with this changeset

## Testing

No tests performed other than visually inspecting build output

## Docs

No docs need updating. This just fixes an obvious typo

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
